### PR TITLE
fix: lock tenant map to avoid race

### DIFF
--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -130,7 +130,9 @@ func (server *MultiTenantServer) getChartList(log cm_logger.LoggingFn, repo stri
 
 func (server *MultiTenantServer) regenerateRepositoryIndex(log cm_logger.LoggingFn, entry *cacheEntry, diff cm_storage.ObjectSliceDiff) <-chan indexRegeneration {
 	ch := make(chan indexRegeneration, 1)
+	server.TenantCacheKeyLock.Lock()
 	tenant := server.Tenants[entry.RepoName]
+	server.TenantCacheKeyLock.Unlock()
 
 	tenant.RegeneratedIndexesChans = append(tenant.RegeneratedIndexesChans, ch)
 


### PR DESCRIPTION
from: https://github.com/helm/chartmuseum/pull/702

[chart-logs.txt](https://github.com/alauda/chartmuseum/files/13608523/chart-logs.txt)
